### PR TITLE
Partial review of dev environment

### DIFF
--- a/tutorials/napps/development_environment_setup.rst
+++ b/tutorials/napps/development_environment_setup.rst
@@ -7,62 +7,63 @@
 Setting up your dev environment
 ###############################
 
+.. NOTE:: We tested this tutorial on Ubuntu. But feel free to adapt to your
+  preferred Linux distribution.
+
 ********
 Overview
 ********
 
 This tutorial shows how to setup your development environment to contribute to
-Kytos Ecossystem code (python-openflow, kyco, kytos NApps and so on). With this
+Kytos Ecosystem code (python-openflow, kyco, kytos NApps and so on). With this
 setup you will also be able to run the *Kytos Controller* (|kyco|_).
 
-.. NOTE:: Do not use this method to install Kytos for production environments.
+.. NOTE:: Do not use this method to install Kytos in production environments.
    This setup is not suitable for production.
+
+.. CAUTION:: Code to be run in terminal begins with the dollar sign ($). If
+  you copy and paste, don't forget to skip this symbol.
 
 .. TODO:: Set the time
 
 The average time to go through it is: XX min
 
 What you will learn
-====================
+===================
 
 * How to create an isolated environment for development
 * How to install the Kytos Projects in a development environment
 * How to install Mininet
 
-*********************************
-Installing the basic dependencies
-*********************************
+********************************
+Installing required dependencies
+********************************
 
-In order to start coding with Kytos you need a basic dependencies. Install it
-with the following command:
+In order to start using and coding with Kytos, you need a few required
+dependencies. One of them is Python 3.6 and it has a special procedure for
+Ubuntu older than 16.10.
 
-.. code-block:: bash
+Python3.6 in old Ubuntu releases
+================================
 
-  $ sudo apt-get install python3-pip git rrdtool librrd-dev libpython3.6-dev python3.6
-
-.. NOTE:: We tested this tutorial on Ubuntu 16.10. But feel free to adapt to
-   your distro.
-
-Installing Python3.6 with Old Ubuntu Release
-============================================
-
-If are you using a old version of Ubuntu, you must add a new PPA to be able
-install a binary package with python3.6.
-
-To add this PPA use the command:
+If are you using Ubuntu older than 16.10, you must add a PPA to be able to
+install Python 3.6 packages. To add this PPA use the command:
 
 .. code-block:: bash
 
-  sudo add-apt-repository ppa:jonathonf/python-3.6
-  sudo apt-get update
+  $ sudo add-apt-repository ppa:jonathonf/python-3.6
+  $ sudo apt-get update
 
 
-Then, if you are using a Ubuntu 16.10 or old, you can install the python3.6
-libraries using the command.
+Required packages
+=================
+
+The required Ubuntu packages can be installed by:
 
 .. code-block:: bash
 
-  sudo apt-get install libpython3.6-dev python3.6
+  $ sudo apt-get install git rrdtool librrd-dev libpython3.6-dev python3.6
+
 
 ********************
 Virtual Environments
@@ -70,9 +71,9 @@ Virtual Environments
 
 First of all, to make changes to Kytos projects we recommend you to use |venv|_.
 The main reason for this recommendation is to keep the dependencies required by
-different projects in separate places, by creating virtual Python environments
-for them. It solves the “Project X depends on version 1.x but, Project Y needs
-4.x” dilemma, and keeps your global site-packages directory clean and
+different projects in separate places by creating virtual Python environments
+for each one. It solves the “Project X depends on version 1.x, but Project Y
+needs 4.x” dilemma, and keeps your global site-packages directory clean and
 manageable.
 
 In this tutorial we will use the |virtualenv|_ package, but if you are used to
@@ -83,42 +84,19 @@ your global system, feel free to do it your way.
 .. Reviewed until here.... ASS: diraol
 
 ********************************
-Setting up a virutal environment
+Setting up a virtual environment
 ********************************
 
-To setup an isolated environment, we need install virtualenv. Virtualenv is a
+To setup an isolated environment, we need to install virtualenv. Virtualenv is a
 tool used to build an isolated environment. In the following sections you will
 learn how to create and manage virtualenvs.
 
 .. code-block:: bash
 
-  $ sudo pip3 install virtualenv
+  $ sudo apt-get install python3.6-venv
 
 Configuring Virtualenv
 ======================
-
-.. To configure the virtualenv we need set the variable *VIRTUALENVWRAPPER_PYTHON*
-.. , update the *PATH* and load the file
-.. **source /usr/local/bin/virtualenvwrapper.sh** before start a bash session. We
-.. can do this using the commands below.
-..
-.. .. code-block:: bash
-..
-..   $ echo "export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python3" >> ~/.bashrc
-..   $ echo "PATH=$PATH:$VIRTUALENVWRAPPER_PYTHON" >> ~/.bashrc
-..   $ echo "source /usr/local/bin/virtualenvwrapper.sh" >> ~/.bashrc
-..
-.. Execute the command below to reload the current bash session:
-..
-.. .. code-block:: bash
-..
-..   $ bash --login
-..
-.. Basics Virtualenvwrapper Commands
-.. =================================
-..
-.. When you are using a virtulenvwrapper you can create, remove, list or use a
-.. virtualenv.
 
 Creating a new virtualenv
 -------------------------
@@ -127,34 +105,24 @@ If you want create a new virtualenv, you must use the command below:
 
 .. code-block:: bash
 
-   $ virtualenv -p /usr/bin/python3.6 test42
+   $ python3.6 -m venv test42
 
 This command will create a virtualenv named *test42* and to use the
 python3.6 as a default python into the environment.
 
-.. NOTE:: Kytos is using python3.6 because of some features included during 3.6
-   release.
+.. NOTE:: Kytos is using python3.6 to leverage some new features of the Python
+  language.
 
 Removing a virtualenv
 ---------------------
 
-If you want to remove a existing virtualenv, you just delete its folder. (In
-this case, it would be rm -rf):
+If you want to remove an existing virtualenv, just delete its folder:
 
 .. code-block:: bash
 
   $ rm -rf test42
 
 After this the virtualenv named *test42* will be removed.
-
-.. Listing all virtualenv created
-.. ------------------------------
-..
-.. If you want to show all virtualenv created, you must use the command below:
-..
-.. .. code-block:: bash
-..
-..   $ lsvirtualenv
 
 Using the virtual environment
 -----------------------------
@@ -165,11 +133,13 @@ If you want to use an existing environment you can use the following command:
 
   $ source test42/bin/activate
 
-After that you console will show the virtualenv activated between parenthesis:
+After that, your console will show the activated virtualenv name between
+parenthesis. Now, update the *pip* package that is installed in every
+virtualenv:
 
 .. code-block:: bash
 
-  (test42) $
+  (test42) $ pip install --upgrade pip
 
 This mean that the test42 is already activated. When you want leave this
 virtualenv you can use the command below:
@@ -178,139 +148,55 @@ virtualenv you can use the command below:
 
   $ deactivate
 
-After this you will use your system environment.
+After this you will use your regular environment and the virtualenv name will
+disappear from your prompt.
 
-.. note:: Inside the virtualenv all pip packages will be installed within the
-   test42 folder, outside the virtualenv all pip packages will be installed into
-   the default system environment.
-
-
-.. If you are interested in read more about the virtualenvwrapper commands you can
-.. access the page `virtualenvwrapper commands
-.. <http://virtualenvwrapper.readthedocs.io/en/latest/command_ref.html>`_.
+.. note:: Inside the virtualenv, all pip packages will be installed within the
+   test42 folder. Outside the virtualenv, all pip packages will be installed
+   into the default system environment (standard Ubuntu folders).
 
 If you want to read more about it, please visit: |virtualenv|_ and
 |virtualenv_docs|_ pages.
 
-***********************************
-Clonning Kytos projects from Github
-***********************************
 
-.. What is GitHub?
-.. ================
-..
-.. GitHub is a web-based version control system and collaborative platform for
-.. software developers.GitHub, which is delivered through a software-as-a-service
-.. (SaaS) business model, was started in 2008 and was founded on Git.
-.. Git is a open source version control system that was started by Linus Torvalds
-.. - the same person who created Linux. Git is similar to other control version
-.. system like Subversion(SVN), Mercurial and CSV.
-..
-.. Configuring git
-.. ===============
-..
-.. This configuration sub-section is based on the page `setup git configuration
-.. <https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup>`_, that
-.. contain first time steps to setup your Git.
-..
-.. Your Identity
-.. -------------
-..
-.. The first thing you should do when you install Git is to set your user name
-.. and email address. This is important because every Git commit uses this
-.. information, and it's immutably baked into the commits you start creating:
-..
-.. .. code-block:: bash
-..
-..   $ git config --global user.name "John Doe"
-..   $ git config --global user.email johndoe@example.com
-..
-.. Your Editor
-.. -----------
-..
-.. Now that your identity is set up, you can configure the default text editor
-.. that will be used when Git needs you to type in a message. If not configured,
-.. Git uses your system’s default editor.
-..
-.. If you want to use a different text editor, such as VIM,
-.. you can do the following:
-..
-.. .. code-block:: bash
-..
-..   $ git config --global core.editor vim
-..
-..
-.. Checking your settings
-.. ----------------------
-..
-.. If you want to check your settings, you can use the command below to list all
-.. the settings Git can find at that point:
-..
-..
-.. .. code-block:: bash
-..
-..   $ git config --list
-..   user.name=John Doe
-..   user.email=johndoe@example.com
-..   color.status=auto
-..   color.branch=auto
-..   color.interactive=auto
-..   color.diff=auto
-..   ...
+******************************
+Using latest Kytos from Github
+******************************
 
 
-Cloning an existing project
-===========================
+Cloning existing projects
+=========================
 
 If you want contribute with a kytos project, you must clone a project found in
 `GitHub group <https://github.com/kytos>`_ to make your changes. Here we are
 going to clone all important repositories (python-openflow, kyco, kytos-utils
-and kyco-core-napps).
+and kyco-core-napps) using the development branch.
 
 .. code-block:: bash
 
-  $ for repo in python-openflow kyco kyco-core-napps kytos-utils; do
-      git clone https://github.com/kytos/"$repo".git
+  $ for project in python-openflow kyco kyco-core-napps kytos-utils; do
+      git clone --branch develop https://github.com/kytos/$project.git; \
     done
 
-After this command a folder with each project will be created and you will find
-all files of the project inside each of them.
+After this command, a folder will be created for each project with the latest
+version of the source code.
 
-..
-.. .. code-block:: bash
-..
-..   $ cd python-openflow/
-..   $ ls
-..   pyof/                         requirements-dev.txt   setup.py
-..   requirements-docs.txt         tests/                 docs/
-..   raw/                          requirements.txt       LICENSE
-..   README.rst                    setup.cfg
-..
 
-*********************************************************
-How to install the projects using development environment
-*********************************************************
+Installing Python dependencies
+==============================
 
-After cloned all projects you must: 1) make sure that you are at "develop"
-branch; 2) install the packages required to run the project. Let's do this on
-all projects that we cloned, with the command:
+Each project requires a set of Python packages that are installed through
+virtualenv. The list of packages are available in files named like
+*requirements\*.txt*. Let's install all of them at once:
 
 .. code-block:: bash
 
-  $ for repo in python-openflow kyco-core-napps kytos-utils kyco; do
-      cd $repo
-      git checkout develop
-      pip install -r requirements.txt
-      pip install -r requirements-dev.txt
-      pip install -r requirements-docs.txt
-      python setup.py develop
-      cd ..
+  $ for project in python-openflow kyco kyco-core-napps kytos-utils; do
+      cd $project; \
+      python setup.py develop || break; \
+      pip install -r requirements.txt -r requirements-dev.txt || break; \
+      cd -; \
     done
-
-
-.. The main projects used in this tutorial are python-openflow, kyco-core-napps,
-.. kytos-utils, and kyco.For each project you can clone, and install the project
-.. using the commands listed above.
 
 Cool! Now you have all dependencies and repositories cloned into your machine.
 One more step: mininet.
@@ -393,4 +279,3 @@ To see more about mininet you can access the webpage `mininet.org
 
 .. |virtualenv_docs| replace:: **virtualenv docs**
 .. _virtualenv_docs: https://virtualenv.pypa.io/en/stable/
-


### PR DESCRIPTION
Fixed several issues. The following still have to be fixed:

```bash
$ cd kyco
$ python setup.py develop
(...)
warning: install_lib: 'build/lib' does not exist -- no Python modules to install

error: Setup script exited with error: SandboxViolation: mkdir('/home/kytos/review-cadu/test42/var', 511) {}

The package setup script has attempted to modify files on your system
that are not within the EasyInstall build area, and has been aborted.

This package cannot be safely installed by EasyInstall, and may not
support alternate installation locations even if you run its setup
script by hand.  Please inform the package's author and the EasyInstall
maintainers to find out if a fix or workaround is available.
```