### PR TITLE
Tutorials fixes

### DIFF
--- a/tutorials/napps/development_environment_setup.rst
+++ b/tutorials/napps/development_environment_setup.rst
@@ -59,7 +59,7 @@ The required Ubuntu packages can be installed by:
 
 .. code-block:: bash
 
-  $ sudo apt install git rrdtool librrd-dev libpython3.6-dev python3.6 python3.6-venv
+  $ sudo apt install git libpython3.6-dev python3.6 python3.6-venv
 
 ********************************
 Setting up a virtual environment

--- a/tutorials/napps/development_environment_setup.rst
+++ b/tutorials/napps/development_environment_setup.rst
@@ -173,6 +173,41 @@ virtualenv.
     done
 
 Cool! Now you have all dependencies and repositories cloned into your machine.
+
+Installing the NApps from Kytos team
+====================================
+
+We will now install the NApps developed by the Kytos team, which will be used
+later in the following tutorials. To enable NApps management, we need Kytos
+running, so open another terminal window, make sure your virtualenv is active
+and run:
+
+.. code-block:: bash
+
+  $ source test42/bin/activate
+  $ kytosd -f
+
+.. NOTE:: Don't worry about the Kytos main screen for now: we will have it
+    explained, as well as NApp management, in the next tutorials.
+
+Now that Kytos is running, switch back to the previous window and install the
+NApps using the ``kytos`` command line utility. You will also disable the NApps,
+just for now.
+
+.. code-block:: bash
+
+  $ kytos napps install kytos/of_core \
+     kytos/of_flow_manager \
+     kytos/of_ipv6drop \
+     kytos/of_l2ls \
+     kytos/of_lldp \
+     kytos/of_topology \
+     kytos/web_topology_layout
+
+  $ kytos napps disable all
+
+That's it! Now, you can go back to the Kytos screen and type ``quit`` to exit
+Kytos.
 One more step: Mininet.
 
 How to install Mininet

--- a/tutorials/napps/restful_statistics.rst
+++ b/tutorials/napps/restful_statistics.rst
@@ -28,8 +28,20 @@ What you will need
 ==================
 
 * :doc:`Kytos and Mininet <how_to_use_kytos_with_mininet>`;
-* The dependencies *rrdtool* and *librrd-dev* (Ubuntu package names) as
-  installed in :doc:`development_environment_setup`.
+
+
+********************************
+Installing required dependencies
+********************************
+
+The NApp used in this tutorial, *kytos/of_stats*, has some dependencies that
+must be installed on your system beforehand. To get them, run:
+
+.. code-block:: bash
+
+  $ sudo apt update
+  $ sudo apt install rrdtool librrd-dev
+  $ pip install rrdtool
 
 *************
 Running Kytos


### PR DESCRIPTION
Fixes described in the PR's review comments:

- Move RRD installation to the of_stats tutorial, and don't install of_stats before that
- Add instructions to install NApps in the dev_env in the first tutorial.