### PR TITLE
Fix #67 and remove some others mistakes in the tutorials.

### DIFF
--- a/tutorials/napps/create_ping_pong_napps.rst
+++ b/tutorials/napps/create_ping_pong_napps.rst
@@ -351,7 +351,7 @@ So, the ``main.py`` file of the ``pong`` napp will be:
             message = 'Hi, here is the Pong NApp answering a ping.'
             message += 'The current time is {}, and the ping was dispatched '
             message += 'at {}.'
-            self.log.info(message.format(datetime.now(),
+            log.info(message.format(datetime.now(),
                                          event.content['message']))
 
         def shutdown(self):

--- a/tutorials/napps/restful_statistics.rst
+++ b/tutorials/napps/restful_statistics.rst
@@ -149,7 +149,7 @@ REST API
 ********
 
 To see some flow statistics, visit
-http://localhost:8181/kytos/stats/00:00:00:00:00:00:00:01/flows.
+http://localhost:8181/api/kytos/of_stats/v1/0:00:00:00:00:00:00:01/flows.
 At any time, refresh the page to get the latest statistics.
 
 This endpoint of *kytos/of_stats* will show statistics of the last second

--- a/tutorials/napps/switch_l2.rst
+++ b/tutorials/napps/switch_l2.rst
@@ -31,7 +31,7 @@ Introduction
 
 Layer 2
 =======
-*Layer 2* refers to the *Data Link layer*, the third one in the |osi_model|_. This layer
+*Layer 2* refers to the *Data Link layer*, the second one in the |osi_model|_. This layer
 is responsible for defining interfaces's fixed addresses for transmitting frames
 in a network as well as control the Physical layer.
 
@@ -110,7 +110,7 @@ You can also add a log message to know when the controller receives a packet.
         in_port = packet_in.in_port.value
         switch = event.source.switch
         switch.update_mac_table(ethernet.source, in_port)
-        log.info('Packet received from %s to %s.', ethernet.source.value',
+        log.info('Packet received from %s to %s.', ethernet.source.value,
                  ethernet.destination.value)
 
             # (Continues...)
@@ -224,33 +224,33 @@ needed imports, and comments were removed to improve readability.
   from pyof.v0x01.common.phy_port import Port
   from pyof.v0x01.controller2switch.flow_mod import FlowMod, FlowModCommand
   from pyof.v0x01.controller2switch.packet_out import PacketOut
-  
+
   from napps.tutorial.of_l2ls import settings
-  
-  
+
+
   class Main(KytosNApp):
-  
+
       def setup(self):
           pass
-  
+
       def execute(self):
           pass
-  
+
       @listen_to('kytos/of_core.v0x01.messages.in.ofpt_packet_in')
       def handle_packet_in(self, event):
           packet_in = event.content['message']
-  
+
           ethernet = Ethernet()
           ethernet.unpack(packet_in.data.value)
-  
+
           in_port = packet_in.in_port.value
           switch = event.source.switch
           switch.update_mac_table(ethernet.source, in_port)
-          log.info('Packet received from %s to %s.', ethernet.source.value',
+          log.info('Packet received from %s to %s.', ethernet.source.value,
                  ethernet.destination.value)
-  
+
           dest_ports = switch.where_is_mac(ethernet.destination)
-  
+
           if dest_ports:
               log.info('%s is at port %d.', ethernet.destination.value, dest_ports[0])
               flow_mod = FlowMod()
@@ -266,21 +266,21 @@ needed imports, and comments were removed to improve readability.
                                               'message': flow_mod})
               self.controller.buffers.msg_out.put(event_out)
               log.info('Flow installed! Subsequent packets will be sent directly.')
-  
+
           packet_out = PacketOut()
           packet_out.buffer_id = packet_in.buffer_id
           packet_out.in_port = packet_in.in_port
           packet_out.data = packet_in.data
-  
+
           port = dest_ports[0] if dest_ports else Port.OFPP_FLOOD
           packet_out.actions.append(ActionOutput(port=port))
           event_out = KytosEvent(name=('tutorial/of_l2ls.messages.out.'
                                        'ofpt_packet_out'),
                                  content={'destination': event.source,
                                           'message': packet_out})
-  
+
           self.controller.buffers.msg_out.put(event_out)
-  
+
       def shutdown(self):
           pass
 


### PR DESCRIPTION
### Fixed:

- #67 Invalid RESTful URL in tutorial;
- Removed an improper single quotation mark in the code;
- Removed an improper `self` in the code;
- Change in the introduction of the tutorial: "Creating a learning switch L2 - Part 1".