### PR TITLE
Fix install instructions on dev documentation (Fix #846)

### DIFF
--- a/tutorials/napps/development_environment_setup.rst
+++ b/tutorials/napps/development_environment_setup.rst
@@ -132,18 +132,23 @@ If you want to read more about it, please visit: |virtualenv|_ and
 Installing the latest Kytos release
 ***********************************
 
-Installing with pip
+Download the kytos project from github
 ===================
 
-To install the latest Kytos from PyPI, just make sure the virtualenv is
-activated and run:
+To download the kytos from github you need run the command below to clone the project locally.
+
 
 .. code-block:: bash
 
-  (test42) $ pip install kytos
+  (test42) $ git clone https://github.com/kytos/kytos.git
 
-This will install Kytos with all the dependencies, like kytos-utils and
-python-openflow.
+After that change the directory to kytos project and install all development dependencies. Below we execute its commands.
+
+
+.. code-block:: bash                                                               
+
+  (test42) $ git cd kytos
+  (test42) $ git pip install -r requirements/dev.txt
 
 Installing the NApps from Kytos team
 ====================================

--- a/tutorials/napps/restful_statistics.rst
+++ b/tutorials/napps/restful_statistics.rst
@@ -147,7 +147,7 @@ REST API
 ********
 
 To see some flow statistics, visit
-http://localhost:8181/api/kytos/of_stats/v1/0:00:00:00:00:00:00:01/flows.
+http://localhost:8181/api/kytos/of_stats/v1/00:00:00:00:00:00:00:01/flows.
 At any time, refresh the page to get the latest statistics.
 
 This endpoint of *kytos/of_stats* will show statistics of the last second


### PR DESCRIPTION
I searched in Tutorials, Developer guide, Documentation (I'm dev) pages for developer-oriented instructions to install kytos from PyPI and edited that part instructing to download Kytos from the latest git master.