### PR TITLE
0 is missing in the first pair of the switch address on RESTfull Statistics NApp tutorial (fix #80)

### DIFF
--- a/tutorials/napps/restful_statistics.rst
+++ b/tutorials/napps/restful_statistics.rst
@@ -147,7 +147,7 @@ REST API
 ********
 
 To see some flow statistics, visit
-http://localhost:8181/api/kytos/of_stats/v1/0:00:00:00:00:00:00:01/flows.
+http://localhost:8181/api/kytos/of_stats/v1/00:00:00:00:00:00:00:01/flows.
 At any time, refresh the page to get the latest statistics.
 
 This endpoint of *kytos/of_stats* will show statistics of the last second


### PR DESCRIPTION
In RESTfull Stat istics NApp tutorial step of the https://tutorials.kytos.io/napps/restful_statistics/ tutorial, a value 0 is missing in the first pair of the switch address (0:00:00:00:00:00:00:01) in the http://localhost:8181/api/kytos/of_stats/v1/0:00:00:00:00:00:00:01/flows URL.