### PR TITLE
Very small changes on text of 'RESTful Statistics NApp' and 'L3 learning switch: Part 2'

### DIFF
--- a/tutorials/napps/restful_statistics.rst
+++ b/tutorials/napps/restful_statistics.rst
@@ -142,7 +142,7 @@ Finally, let's generate 5 packets per second from host h1 to h2 with:
   mininet> h1 ping -i 0.2 h2
 
 
-.. note:: If by using the command above you perhaps got `ping: bad timing interval: 0.2`  as an answer from the mininet, you can solve it by just changing the notation `'0.2'` to `'0,2'` in your interval, or you can run `export LC_NUMERIC="en_US.UTF-8` in your terminal to make sure that at least locale you are using the `en_US.UTF-8` notation. Or you can also change for system wide  by using `echo 'export LC_NUMERIC="en_US.UTF-8"' >>~/.bashrc`
+.. note:: If by using the command above you perhaps got `ping: bad timing interval: 0.2`  as an answer from the mininet, you can solve it by just changing the notation `'0.2'` to `'0,2'` in your interval, or you can run `export LC_NUMERIC="en_US.UTF-8` in your terminal to make sure that at least locale you are using the `en_US.UTF-8` notation.
 
 ********
 REST API
@@ -198,7 +198,7 @@ humans to understand the data. Let's take a closer look at some lines:
 *Bps* and *pps* mean bytes per second and packets per second, respectively.
 As we are sending one ping every 0.2 seconds, *pps* will be close to 5.
 
-In the Mininet console, hit ``ctrl+c`` and run ``h1 ping -i 0,5 h2``.
+In the Mininet console, hit ``ctrl+c`` and run ``h1 ping -i 0.5 h2``.
 After a few seconds, *pps* will be close to 2.
 
 ********

--- a/tutorials/napps/restful_statistics.rst
+++ b/tutorials/napps/restful_statistics.rst
@@ -139,7 +139,7 @@ Finally, let's generate 5 packets per second from host h1 to h2 with:
 
 .. code-block:: console
 
-  mininet> h1 ping -i 0.2 h2
+  mininet> h1 ping -i 0,2 h2
 
 
 ********

--- a/tutorials/napps/restful_statistics.rst
+++ b/tutorials/napps/restful_statistics.rst
@@ -139,8 +139,10 @@ Finally, let's generate 5 packets per second from host h1 to h2 with:
 
 .. code-block:: console
 
-  mininet> h1 ping -i 0,2 h2
+  mininet> h1 ping -i 0.2 h2
 
+
+.. note:: If by using the command above you perhaps got `ping: bad timing interval: 0.2`  as an answer from the mininet, you can solve it by just changing the notation `'0.2'` to `'0,2'` in your interval, or you can run `export LC_NUMERIC="en_US.UTF-8` in your terminal to make sure that at least locale you are using the `en_US.UTF-8` notation. Or you can also change for system wide  by using `echo 'export LC_NUMERIC="en_US.UTF-8"' >>~/.bashrc`
 
 ********
 REST API
@@ -196,7 +198,7 @@ humans to understand the data. Let's take a closer look at some lines:
 *Bps* and *pps* mean bytes per second and packets per second, respectively.
 As we are sending one ping every 0.2 seconds, *pps* will be close to 5.
 
-In the Mininet console, hit ``ctrl+c`` and run ``h1 ping -i 0.5 h2``.
+In the Mininet console, hit ``ctrl+c`` and run ``h1 ping -i 0,5 h2``.
 After a few seconds, *pps* will be close to 2.
 
 ********

--- a/tutorials/napps/restful_statistics.rst
+++ b/tutorials/napps/restful_statistics.rst
@@ -142,7 +142,11 @@ Finally, let's generate 5 packets per second from host h1 to h2 with:
   mininet> h1 ping -i 0.2 h2
 
 
-.. note:: If by using the command above you perhaps got `ping: bad timing interval: 0.2`  as an answer from the mininet, you can solve it by just changing the notation `'0.2'` to `'0,2'` in your interval, or you can run `export LC_NUMERIC="en_US.UTF-8` in your terminal to make sure that at least locale you are using the `en_US.UTF-8` notation.
+.. note:: If the command above returned `ping: bad timing interval: 0.2`, 
+you can fix it by just changing the notation `'0.2'` to `'0,2'` in your
+interval parameter, or you can run `export LC_NUMERIC="en_US.UTF-8"` in
+the terminal just before running mininet to make sure that you are using the
+English numeric notation.
 
 ********
 REST API

--- a/tutorials/napps/switch_l3_part2.rst
+++ b/tutorials/napps/switch_l3_part2.rst
@@ -128,7 +128,7 @@ First you will create an ARP table, to store known associations of IP addresses
 to MAC addresses in the network. You will also create a forwarding table to
 learn at which physical port each IP address can be reached.
 
-The tables are implemented as Python dictionaries. The metod needs a decorator
+The tables are implemented as Python dictionaries. The method needs a decorator
 in order to listen to the Kytos's *new switch* event.
 
 .. code-block:: python3


### PR DESCRIPTION
1. When following the [RESTful Statistics NApp](https://tutorials.kytos.io/napps/restful_statistics/), the documentation points this command to use with the mininet:  `mininet> h1 ping -i 0.2 h2` but the mininet answers with: `ping: bad timing interval: 0.2` so changing to `mininet> h1 ping -i 0,2 h2` everything goes well and the command works by answering with `PING 10.0.0.2 (10.0.0.2) 56(84) bytes of data`. 

2. The second change is just a typo on [L3 learning switch: Part 2](https://tutorials.kytos.io/napps/switch_l3_part2/), where the word `method` were, I believe, was with a error on its spelling, so: 
``` 
 -The tables are implemented as Python dictionaries. The _metod_ needs a decorator
 +The tables are implemented as Python dictionaries. The _method_ needs a decorator
```
 