### PR TITLE
Call python3 explicitly on the examples

### DIFF
--- a/tutorials/napps/create_looping_napp.rst
+++ b/tutorials/napps/create_looping_napp.rst
@@ -242,7 +242,7 @@ To install locally, you have to run the following commands:
 .. code-block:: console
 
   $ cd ~/tutorials/<username>/loopnapp
-  $ python setup.py develop
+  $ python3 setup.py develop
 
 To install remotely, you have to publish it first:
 

--- a/tutorials/napps/create_ping_pong_napps.rst
+++ b/tutorials/napps/create_ping_pong_napps.rst
@@ -424,7 +424,7 @@ To install locally, you have to run the following commands:
 
   for napp in ping pong; do
     $ cd ~/tutorials/<username>/{napp}
-    $ python setup.py develop
+    $ python3 setup.py develop
   done
 
 To install remotely, you have to publish them first:

--- a/tutorials/napps/create_your_napp.rst
+++ b/tutorials/napps/create_your_napp.rst
@@ -319,7 +319,7 @@ To install locally, you have to run the following commands:
 .. code-block:: console
 
   $ cd ~/tutorials/<username>/helloworld
-  $ python setup.py develop
+  $ python3 setup.py develop
 
 To install remotely, you have to publish it first:
 

--- a/tutorials/napps/how_to_protect_a_napp_rest_endpoint.rst
+++ b/tutorials/napps/how_to_protect_a_napp_rest_endpoint.rst
@@ -161,7 +161,7 @@ Open another terminal and install your application:
 
 .. code-block:: console
 
-    $ python setup.py develop
+    $ python3 setup.py develop
 
 Check if your application is installed and running with the command:
 

--- a/tutorials/napps/switch_l2.rst
+++ b/tutorials/napps/switch_l2.rst
@@ -348,7 +348,7 @@ To install locally, you have to run the following commands:
 .. code-block:: console
 
   $ cd ~/tutorials/<username>/of_l2ls
-  $ python setup.py develop
+  $ python3 setup.py develop
 
 To install remotely, you have to publish it first:
 

--- a/tutorials/napps/switch_l3_part1.rst
+++ b/tutorials/napps/switch_l3_part1.rst
@@ -363,7 +363,7 @@ To install locally, you have to run the following commands:
 .. code-block:: console
 
   $ cd ~/tutorials/<username>/of_l3ls
-  $ python setup.py develop
+  $ python3 setup.py develop
 
 To install remotely, you have to publish it first:
 

--- a/tutorials/napps/switch_l3_part2.rst
+++ b/tutorials/napps/switch_l3_part2.rst
@@ -552,7 +552,7 @@ To install locally, you have to run the following commands:
 .. code-block:: console
 
   $ cd ~/tutorials/<username>/of_l3ls_v2
-  $ python setup.py develop
+  $ python3 setup.py develop
 
 To install remotely, you have to publish it first:
 


### PR DESCRIPTION
Avoid calling python2 if this is a system-wide install.
