### PR TITLE
Remove python3.6 references

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -1,8 +1,8 @@
 Installing
 ==========
 
-We use python3.6. So in order to use this software please install python3.6
-into your environment beforehand.
+In order to use this software please install python version 3.6 or 
+greater into your environment beforehand.
 
 We are doing a huge effort to make Kytos and its components available on all
 common distros. So, we recommend you to download it from your distro
@@ -24,7 +24,7 @@ install procedure:
 .. code-block:: shell
 
    $ cd kytos
-   $ sudo python3.6 setup.py install
+   $ sudo python3 setup.py install
 
 Configuring
 ===========


### PR DESCRIPTION
### :octocat: Are you working on some issue? Identify the issue!

Related https://github.com/kytos/kytos/issues/1149

### :bookmark_tabs: Description of the Change

Update the instruction how install kytos.

### :page_facing_up: Release Notes

- Remove python3.6 references

